### PR TITLE
CUDA op_plan: correctly populate loc_maps

### DIFF
--- a/op2/c/src/cuda/op_cuda_rt_support.c
+++ b/op2/c/src/cuda/op_cuda_rt_support.c
@@ -200,6 +200,7 @@ op_plan * op_plan_get ( char const * name, op_set set, int part_size,
     int counter = 0;
     for ( int m = 0; m < nargs; m++ ) if ( plan->loc_maps[m] != NULL ) counter++;
     op_mvHostToDevice ( ( void ** ) &( plan->loc_map ), sizeof ( short ) * counter * set_size );
+    counter = 0;
     for ( int m = 0; m < nargs; m++ ) if ( plan->loc_maps[m] != NULL ) {
       plan->loc_maps[m] = &plan->loc_map[set_size * counter]; counter++;
     }


### PR DESCRIPTION
On CUDA, the loc_maps array was being incorrectly populated, because the offset into loc_map was calculated incorrectly.  This fixes things.
