### PR TITLE
Fix binding of op_decl_dat in fortran interface

### DIFF
--- a/op2/fortran/src/backend/op2_for_declarations.F90
+++ b/op2/fortran/src/backend/op2_for_declarations.F90
@@ -143,7 +143,7 @@ module OP2_Fortran_Declarations
 
     end function op_decl_null_map
 
-    type(c_ptr) function op_decl_dat_c ( set, datdim, type, datsize, dat, name ) BIND(C,name='op_decl_dat')
+    type(c_ptr) function op_decl_dat_c ( set, datdim, type, datsize, dat, name ) BIND(C,name='op_decl_dat_char')
 
       use, intrinsic :: ISO_C_BINDING
 


### PR DESCRIPTION
b1422f2 (Core library cleanup) removed the name `op_decl_dat` in favour
of `op_decl_dat_char`.  The fortran interface was not updated in line
with this change and thus if you built 

```
./cmake.local -DOP2_ENABLE_FORTRAN_INTERFACE=Yes
```

you would get an undefined symbol error when linking against the op2
libraries.  To fix this, just bind `op_decl_dat_c` in the fortran
interface against `op_decl_dat_char`, rather than `op_decl_dat`.
