### PR TITLE
Properly clean up in op_exit and op_rt_exit

### DIFF
--- a/op2/c/src/core/op_lib_core.c
+++ b/op2/c/src/core/op_lib_core.c
@@ -265,6 +265,7 @@ op_exit_core (  )
     free ( OP_set_list[i] );
   }
   free ( OP_set_list );
+  OP_set_list = NULL;
 
   for ( int i = 0; i < OP_map_index; i++ )
   {
@@ -274,6 +275,7 @@ op_exit_core (  )
     free ( OP_map_list[i] );
   }
   free ( OP_map_list );
+  OP_map_list = NULL;
 
   for ( int i = 0; i < OP_dat_index; i++ )
   {
@@ -284,10 +286,12 @@ op_exit_core (  )
     free ( OP_dat_list[i] );
   }
   free ( OP_dat_list );
+  OP_dat_list = NULL;
 
   // free storage for timing info
 
   free ( OP_kernels );
+  OP_kernels = NULL;
 
   // reset initial values
 

--- a/op2/c/src/core/op_rt_support.c
+++ b/op2/c/src/core/op_rt_support.c
@@ -76,6 +76,7 @@ op_rt_exit (  )
   OP_plan_max = 0;
 
   free ( OP_plans );
+  OP_plans = NULL;
 }
 
 /*


### PR DESCRIPTION
`op_exit` and `op_rt_exit` did not properly clean up, causing a memory corruption when calling `op_init` again after `op_exit` has been called. Fix that by `NULL`ing global core data structure arrays after freeing in `op_exit` and `op_rt_exit`.
