### PR TITLE
Fix printf modifiers for size_t which broke builds on 32-bit systems.

### DIFF
--- a/op2/c/src/externlib/op_hdf5.c
+++ b/op2/c/src/externlib/op_hdf5.c
@@ -256,7 +256,7 @@ op_dat op_decl_dat_hdf5(op_set set, int dim, char const *type, char const *file,
 
     if(dat_size != dim*sizeof(double))
     {
-      printf("dat.size %lu in file %s and %d*sizeof(double) do not match\n",dat_size,file,dim);
+      printf("dat.size %zu in file %s and %d*sizeof(double) do not match\n",dat_size,file,dim);
       exit(2);
     }
     else
@@ -269,7 +269,7 @@ op_dat op_decl_dat_hdf5(op_set set, int dim, char const *type, char const *file,
 
     if(dat_size != dim*sizeof(float))
     {
-      printf("dat.size %lu in file %s and %d*sizeof(float) do not match\n",dat_size,file,dim);
+      printf("dat.size %zu in file %s and %d*sizeof(float) do not match\n",dat_size,file,dim);
       exit(2);
     }
     else
@@ -282,7 +282,7 @@ op_dat op_decl_dat_hdf5(op_set set, int dim, char const *type, char const *file,
 
     if(dat_size != dim*sizeof(int))
     {
-      printf("dat.size %lu in file %s and %d*sizeof(int) do not match\n",dat_size,file,dim);
+      printf("dat.size %zu in file %s and %d*sizeof(int) do not match\n",dat_size,file,dim);
       exit(2);
     }
     else
@@ -295,7 +295,7 @@ op_dat op_decl_dat_hdf5(op_set set, int dim, char const *type, char const *file,
 
     if(dat_size != dim*sizeof(long))
     {
-      printf("dat.size %lu in file %s and %d*sizeof(int) do not match\n",dat_size,file,dim);
+      printf("dat.size %zu in file %s and %d*sizeof(int) do not match\n",dat_size,file,dim);
       exit(2);
     }
     else
@@ -308,7 +308,7 @@ op_dat op_decl_dat_hdf5(op_set set, int dim, char const *type, char const *file,
 
     if(dat_size != dim*sizeof(long long))
     {
-      printf("dat.size %lu in file %s and %d*sizeof(int) do not match\n",dat_size,file,dim);
+      printf("dat.size %zu in file %s and %d*sizeof(int) do not match\n",dat_size,file,dim);
       exit(2);
     }
     else

--- a/op2/c/src/mpi/op_mpi_hdf5.c
+++ b/op2/c/src/mpi/op_mpi_hdf5.c
@@ -383,7 +383,7 @@ op_dat op_decl_dat_hdf5(op_set set, int dim, char const *type, char const *file,
 
     if(dat_size != dim*sizeof(double))
     {
-      printf("dat.size %lu in file %s and %d*sizeof(double) do not match\n",dat_size,file,dim);
+      printf("dat.size %zu in file %s and %d*sizeof(double) do not match\n",dat_size,file,dim);
       MPI_Abort(OP_MPI_HDF5_WORLD, 2);
     }
     else
@@ -396,7 +396,7 @@ op_dat op_decl_dat_hdf5(op_set set, int dim, char const *type, char const *file,
 
     if(dat_size != dim*sizeof(float))
     {
-      printf("dat.size %lu in file %s and %d*sizeof(float) do not match\n",dat_size,file,dim);
+      printf("dat.size %zu in file %s and %d*sizeof(float) do not match\n",dat_size,file,dim);
       MPI_Abort(OP_MPI_HDF5_WORLD, 2);
     }
     else
@@ -409,7 +409,7 @@ op_dat op_decl_dat_hdf5(op_set set, int dim, char const *type, char const *file,
 
     if(dat_size != dim*sizeof(int))
     {
-      printf("dat.size %lu in file %s and %d*sizeof(int) do not match\n",dat_size,file,dim);
+      printf("dat.size %zu in file %s and %d*sizeof(int) do not match\n",dat_size,file,dim);
       MPI_Abort(OP_MPI_HDF5_WORLD, 2);
     }
     else


### PR DESCRIPTION
This commit fixes printing of size_t values which should be done using the 'z' modifier. Without this, building fails on i386 systems since an unsigned long is not the same type as a size_t and strict GCC options are enabled.
