### PR TITLE
Fixing circular mapping partitioning bug

### DIFF
--- a/op2/c/src/mpi/op_mpi_core.c
+++ b/op2/c/src/mpi/op_mpi_core.c
@@ -1497,9 +1497,9 @@ void op_halo_permap_create() {
 
   OP_map_partial_exchange = (int *)malloc(OP_map_index*sizeof(int));
   for (int i = 0; i < OP_map_index; i++) {
-    OP_map_partial_exchange[i] = (double)reduced_map_halo_sizes[i] <
-                      (double)reduced_total_halo_sizes[OP_map_list[i]->to->index]*0.3;
-    if (rank == 0 && OP_diags>1) printf("Mapping %s partially exchanged: %d (%d < 0.3*%d)\n", OP_map_list[i]->name, OP_map_partial_exchange[i], reduced_map_halo_sizes[i], reduced_total_halo_sizes[OP_map_list[i]->to->index]);
+    OP_map_partial_exchange[i] = 0;//(double)reduced_map_halo_sizes[i] <
+                      //(double)reduced_total_halo_sizes[OP_map_list[i]->to->index]*0.3;
+    //if (rank == 0 && OP_diags>1) printf("Mapping %s partially exchanged: %d (%d < 0.3*%d)\n", OP_map_list[i]->name, OP_map_partial_exchange[i], reduced_map_halo_sizes[i], reduced_total_halo_sizes[OP_map_list[i]->to->index]);
   }
   free(reduced_total_halo_sizes);
   free(reduced_map_halo_sizes);

--- a/op2/c/src/mpi/op_mpi_part_core.c
+++ b/op2/c/src/mpi/op_mpi_part_core.c
@@ -679,7 +679,7 @@ static void partition_all(op_set primary_set, int my_rank, int comm_size)
         part to_set = OP_part_list[map->to->index];
         part from_set = OP_part_list[map->from->index];
 
-        if(to_set->is_partitioned == 1)
+        if(to_set->is_partitioned == 1 && from_set->is_partitioned == 0)
         {
           if( partition_from_set(map, my_rank, comm_size, part_range) > 0)
           {
@@ -690,7 +690,7 @@ static void partition_all(op_set primary_set, int my_rank, int comm_size)
           else //partitioning unsuccessful with this map- find another map
             cost[selected] = 99;
         }
-        else if(from_set->is_partitioned == 1)
+        else if(from_set->is_partitioned == 1 && to_set->is_partitioned == 0)
         {
           if( partition_to_set(map, my_rank, comm_size, part_range) > 0)
           {
@@ -700,6 +700,9 @@ static void partition_all(op_set primary_set, int my_rank, int comm_size)
           }
           else //partitioning unsuccessful with this map - find another map
             cost[selected] = 99;
+        }
+        else {
+          cost[selected] = 99;
         }
       }
       else //partitioning error;


### PR DESCRIPTION
This is to fix an issue with partitioning sets and maps, also, temporarily disables partial halo exchanges, until a bug in an obscure case is fixed.
