### PR TITLE
Removed vestigial malloc's that are wrongly zeroing data.

### DIFF
--- a/apps/c/airfoil/airfoil_hdf5/dp/convert_mesh.cpp
+++ b/apps/c/airfoil/airfoil_hdf5/dp/convert_mesh.cpp
@@ -162,20 +162,6 @@ int main(int argc, char **argv) {
 
   fclose(fp);
 
-
-  cell = (int *)op_malloc(4 * ncell * sizeof(int));
-  edge = (int *)op_malloc(2 * nedge * sizeof(int));
-  ecell = (int *)op_malloc(2 * nedge * sizeof(int));
-  bedge = (int *)op_malloc(2 * nbedge * sizeof(int));
-  becell = (int *)op_malloc(nbedge * sizeof(int));
-  bound = (int *)op_malloc(nbedge * sizeof(int));
-
-  x = (double *)op_malloc(2 * nnode * sizeof(double));
-  q = (double *)op_malloc(4 * ncell * sizeof(double));
-  qold = (double *)op_malloc(4 * ncell * sizeof(double));
-  res = (double *)op_malloc(4 * ncell * sizeof(double));
-  adt = (double *)op_malloc(ncell * sizeof(double));
-
   /**------------------------END I/O  -----------------------**/
 
   /* FIXME: It's not clear to the compiler that sth. is going on behind the


### PR DESCRIPTION
These op_malloc's are leftover from when this code used to do a scattering (see commit 58a66814bb3c22975aa123596f07b4e779f02482 ). 