### PR TITLE
Remove INCLUDE_DIRECTORIES from airfoil apps

### DIFF
--- a/apps/c/airfoil/airfoil_plain/CMakeLists.txt
+++ b/apps/c/airfoil/airfoil_plain/CMakeLists.txt
@@ -60,12 +60,12 @@ foreach(VARIANT ${OP2_BUILD_VARIANTS})
 
   # MPI + CUDA version
   op2_application(airfoil_${VARIANT}_mpi_cuda DEPENDS AIRFOIL_grid LIBS op2_mpi_cuda
-    INCLUDE_DIRECTORIES ${VARIANT} SOURCES ${VARIANT}/airfoil_mpi_op.cpp ${VARIANT}/cuda/airfoil_kernels.cu
+    SOURCES ${VARIANT}/airfoil_mpi_op.cpp ${VARIANT}/cuda/airfoil_kernels.cu
     ${VARIANT}/save_soln.h ${VARIANT}/adt_calc.h ${VARIANT}/res_calc.h ${VARIANT}/bres_calc.h ${VARIANT}/update.h)
 
   #MPI + OpenMP version
   op2_application(airfoil_${VARIANT}_mpi_openmp DEPENDS AIRFOIL_grid LIBS op2_mpi op2_openmp
-    INCLUDE_DIRECTORIES ${VARIANT} SOURCES ${VARIANT}/airfoil_mpi_op.cpp ${VARIANT}/openmp/airfoil_kernels.cpp
+    SOURCES ${VARIANT}/airfoil_mpi_op.cpp ${VARIANT}/openmp/airfoil_kernels.cpp
     ${VARIANT}/save_soln.h ${VARIANT}/adt_calc.h ${VARIANT}/res_calc.h ${VARIANT}/bres_calc.h ${VARIANT}/update.h)
 
 endforeach()


### PR DESCRIPTION
On later cmake versions this is causing configuration errors which lead
to to some airfoil* apps not to be configured. In particular it affects
mpi_cuda and mpi_openmp variants. After removing, apps configure, build
and run properly.