### PR TITLE
re-order const declaration and includes

### DIFF
--- a/translator/c/python/op2_gen_cuda.py
+++ b/translator/c/python/op2_gen_cuda.py
@@ -953,17 +953,17 @@ def op2_gen_cuda(master, date, consts, kernels, sets):
 
   file_text = ''
   comm('header')
+  comm('global constants')
+  code('#ifndef MAX_CONST_SIZE')
+  code('#define MAX_CONST_SIZE 128')
+  code('#endif')
+  code('')
   if os.path.exists('./user_types.h'):
     code('#define OP_FUN_PREFIX __host__ __device__')
     code('#include "../user_types.h"')
   code('#include "op_lib_cpp.h"')
   code('#include "op_cuda_rt_support.h"')
   code('#include "op_cuda_reduction.h"')
-  code('')
-  comm('global constants')
-  code('#ifndef MAX_CONST_SIZE')
-  code('#define MAX_CONST_SIZE 128')
-  code('#endif')
   code('')
 
   for nc in range (0,len(consts)):

--- a/translator/c/python/op2_gen_cuda.py
+++ b/translator/c/python/op2_gen_cuda.py
@@ -958,14 +958,6 @@ def op2_gen_cuda(master, date, consts, kernels, sets):
   code('#define MAX_CONST_SIZE 128')
   code('#endif')
   code('')
-  if os.path.exists('./user_types.h'):
-    code('#define OP_FUN_PREFIX __host__ __device__')
-    code('#include "../user_types.h"')
-  code('#include "op_lib_cpp.h"')
-  code('#include "op_cuda_rt_support.h"')
-  code('#include "op_cuda_reduction.h"')
-  code('')
-
   for nc in range (0,len(consts)):
     if consts[nc]['dim']==1:
       code('__constant__ '+consts[nc]['type'][1:-1]+' '+consts[nc]['name']+';')
@@ -976,6 +968,14 @@ def op2_gen_cuda(master, date, consts, kernels, sets):
         num = 'MAX_CONST_SIZE'
 
       code('__constant__ '+consts[nc]['type'][1:-1]+' '+consts[nc]['name']+'['+num+'];')
+
+  if os.path.exists('./user_types.h'):
+    code('#define OP_FUN_PREFIX __host__ __device__')
+    code('#include "../user_types.h"')
+  code('#include "op_lib_cpp.h"')
+  code('#include "op_cuda_rt_support.h"')
+  code('#include "op_cuda_reduction.h"')
+  code('')
 
   # if any_soa:
   #   code('__constant__ int op2_stride;')

--- a/translator/c/python/op2_gen_cuda.py
+++ b/translator/c/python/op2_gen_cuda.py
@@ -952,12 +952,14 @@ def op2_gen_cuda(master, date, consts, kernels, sets):
 ##########################################################################
 
   file_text = ''
-  comm('header')
+
   comm('global constants')
+
   code('#ifndef MAX_CONST_SIZE')
   code('#define MAX_CONST_SIZE 128')
   code('#endif')
   code('')
+
   for nc in range (0,len(consts)):
     if consts[nc]['dim']==1:
       code('__constant__ '+consts[nc]['type'][1:-1]+' '+consts[nc]['name']+';')
@@ -968,7 +970,9 @@ def op2_gen_cuda(master, date, consts, kernels, sets):
         num = 'MAX_CONST_SIZE'
 
       code('__constant__ '+consts[nc]['type'][1:-1]+' '+consts[nc]['name']+'['+num+'];')
+  code('')
 
+  comm('header')
   if os.path.exists('./user_types.h'):
     code('#define OP_FUN_PREFIX __host__ __device__')
     code('#include "../user_types.h"')

--- a/translator/c/python/op2_gen_cuda_simple.py
+++ b/translator/c/python/op2_gen_cuda_simple.py
@@ -1170,16 +1170,6 @@ def op2_gen_cuda_simple(master, date, consts, kernels,sets, macro_defs):
   code('#define MAX_CONST_SIZE 128')
   code('#endif')
   code('')
-  if os.path.exists('./user_types.h'):
-    code('#define OP_FUN_PREFIX __device__ __host__')
-    code('#include "../user_types.h"')
-  comm('header')
-  code('#include "op_lib_cpp.h"')
-  code('')
-  code('#include "op_cuda_rt_support.h"')
-  code('#include "op_cuda_reduction.h"')
-  code('')
-
   for nc in range (0,len(consts)):
     if consts[nc]['dim']==1:
       code('__constant__ '+consts[nc]['type'][1:-1]+' '+consts[nc]['name']+';')
@@ -1190,6 +1180,16 @@ def op2_gen_cuda_simple(master, date, consts, kernels,sets, macro_defs):
         num = 'MAX_CONST_SIZE'
 
       code('__constant__ '+consts[nc]['type'][1:-1]+' '+consts[nc]['name']+'['+num+'];')
+  code('')
+
+  if os.path.exists('./user_types.h'):
+    code('#define OP_FUN_PREFIX __device__ __host__')
+    code('#include "../user_types.h"')
+  comm('header')
+  code('#include "op_lib_cpp.h"')
+  code('')
+  code('#include "op_cuda_rt_support.h"')
+  code('#include "op_cuda_reduction.h"')
 
   code('')
   code('void op_decl_const_char(int dim, char const *type,')

--- a/translator/c/python/op2_gen_cuda_simple.py
+++ b/translator/c/python/op2_gen_cuda_simple.py
@@ -1165,6 +1165,11 @@ def op2_gen_cuda_simple(master, date, consts, kernels,sets, macro_defs):
 ##########################################################################
 
   file_text = ''
+  comm('global constants')
+  code('#ifndef MAX_CONST_SIZE')
+  code('#define MAX_CONST_SIZE 128')
+  code('#endif')
+  code('')
   if os.path.exists('./user_types.h'):
     code('#define OP_FUN_PREFIX __device__ __host__')
     code('#include "../user_types.h"')
@@ -1173,11 +1178,6 @@ def op2_gen_cuda_simple(master, date, consts, kernels,sets, macro_defs):
   code('')
   code('#include "op_cuda_rt_support.h"')
   code('#include "op_cuda_reduction.h"')
-  code('')
-  comm('global constants')
-  code('#ifndef MAX_CONST_SIZE')
-  code('#define MAX_CONST_SIZE 128')
-  code('#endif')
   code('')
 
   for nc in range (0,len(consts)):

--- a/translator/c/python/op2_gen_cuda_simple.py
+++ b/translator/c/python/op2_gen_cuda_simple.py
@@ -1165,11 +1165,14 @@ def op2_gen_cuda_simple(master, date, consts, kernels,sets, macro_defs):
 ##########################################################################
 
   file_text = ''
+
   comm('global constants')
+
   code('#ifndef MAX_CONST_SIZE')
   code('#define MAX_CONST_SIZE 128')
   code('#endif')
   code('')
+
   for nc in range (0,len(consts)):
     if consts[nc]['dim']==1:
       code('__constant__ '+consts[nc]['type'][1:-1]+' '+consts[nc]['name']+';')
@@ -1182,12 +1185,12 @@ def op2_gen_cuda_simple(master, date, consts, kernels,sets, macro_defs):
       code('__constant__ '+consts[nc]['type'][1:-1]+' '+consts[nc]['name']+'['+num+'];')
   code('')
 
+  comm('header')
+
   if os.path.exists('./user_types.h'):
     code('#define OP_FUN_PREFIX __device__ __host__')
     code('#include "../user_types.h"')
-  comm('header')
   code('#include "op_lib_cpp.h"')
-  code('')
   code('#include "op_cuda_rt_support.h"')
   code('#include "op_cuda_reduction.h"')
 

--- a/translator/c/python/op2_gen_mpi_vec.py
+++ b/translator/c/python/op2_gen_mpi_vec.py
@@ -685,10 +685,6 @@ def op2_gen_mpi_vec(master, date, consts, kernels):
 ##########################################################################
 
   file_text =''
-  comm(' header                 ')
-  if os.path.exists('./user_types.h'):
-    code('#include "../user_types.h"')
-  code('#include "op_lib_cpp.h"       ')
   code('#define double_ALIGN 128')
   code('#define float_ALIGN 64')
   code('#define int_ALIGN 64')
@@ -703,6 +699,7 @@ def op2_gen_mpi_vec(master, date, consts, kernels):
   code('#define ALIGNED_int')
   code('#endif')
   code('')
+
   comm(' global constants       ')
 
   for nc in range (0,len(consts)):
@@ -713,8 +710,12 @@ def op2_gen_mpi_vec(master, date, consts, kernels):
         num = str(consts[nc]['dim'])
       else:
         num = 'MAX_CONST_SIZE'
-
       code('extern '+consts[nc]['type'][1:-1]+' '+consts[nc]['name']+'['+num+'];')
+
+  comm(' header                 ')
+  if os.path.exists('./user_types.h'):
+    code('#include "../user_types.h"')
+  code('#include "op_lib_cpp.h"')
 
   comm(' user kernel files')
 

--- a/translator/c/python/op2_gen_mpi_vec.py
+++ b/translator/c/python/op2_gen_mpi_vec.py
@@ -685,6 +685,7 @@ def op2_gen_mpi_vec(master, date, consts, kernels):
 ##########################################################################
 
   file_text =''
+
   code('#define double_ALIGN 128')
   code('#define float_ALIGN 64')
   code('#define int_ALIGN 64')
@@ -711,11 +712,14 @@ def op2_gen_mpi_vec(master, date, consts, kernels):
       else:
         num = 'MAX_CONST_SIZE'
       code('extern '+consts[nc]['type'][1:-1]+' '+consts[nc]['name']+'['+num+'];')
+  code('')
 
   comm(' header                 ')
+
   if os.path.exists('./user_types.h'):
     code('#include "../user_types.h"')
   code('#include "op_lib_cpp.h"')
+  code('')
 
   comm(' user kernel files')
 

--- a/translator/c/python/op2_gen_omp_vec.py
+++ b/translator/c/python/op2_gen_omp_vec.py
@@ -780,8 +780,6 @@ def op2_gen_omp_vec(master, date, consts, kernels):
 ##########################################################################
 
   file_text =''
-  comm(' header                 ')
-  code('#include "op_lib_cpp.h"       ')
   code('#define double_ALIGN 128')
   code('#define float_ALIGN 64')
   code('#define int_ALIGN 64')
@@ -798,6 +796,7 @@ def op2_gen_omp_vec(master, date, consts, kernels):
   code('#endif')
   code('#undef VECTORIZE')
   code('')
+
   comm(' global constants       ')
 
   for nc in range (0,len(consts)):
@@ -808,8 +807,14 @@ def op2_gen_omp_vec(master, date, consts, kernels):
         num = str(consts[nc]['dim'])
       else:
         num = 'MAX_CONST_SIZE'
-
       code('extern '+consts[nc]['type'][1:-1]+' '+consts[nc]['name']+'['+num+'];')
+
+
+  comm(' header                ')
+  code('#include "op_lib_cpp.h"')
+  if os.path.exists('./user_types.h'):
+    code('#include "../user_types.h"')
+  code('#include "op_lib_cpp.h"')
 
   comm(' user kernel files')
 

--- a/translator/c/python/op2_gen_omp_vec.py
+++ b/translator/c/python/op2_gen_omp_vec.py
@@ -780,6 +780,7 @@ def op2_gen_omp_vec(master, date, consts, kernels):
 ##########################################################################
 
   file_text =''
+
   code('#define double_ALIGN 128')
   code('#define float_ALIGN 64')
   code('#define int_ALIGN 64')
@@ -808,13 +809,15 @@ def op2_gen_omp_vec(master, date, consts, kernels):
       else:
         num = 'MAX_CONST_SIZE'
       code('extern '+consts[nc]['type'][1:-1]+' '+consts[nc]['name']+'['+num+'];')
-
+  code('')
 
   comm(' header                ')
+
   code('#include "op_lib_cpp.h"')
   if os.path.exists('./user_types.h'):
     code('#include "../user_types.h"')
   code('#include "op_lib_cpp.h"')
+  code('')
 
   comm(' user kernel files')
 

--- a/translator/c/python/op2_gen_openacc.py
+++ b/translator/c/python/op2_gen_openacc.py
@@ -615,11 +615,6 @@ def op2_gen_openacc(master, date, consts, kernels):
 ##########################################################################
 
   file_text =''
-  comm(' header                 ')
-  if os.path.exists('./user_types.h'):
-    code('#include "../user_types.h"')
-  code('#include "op_lib_c.h"       ')
-  code('')
   comm(' global constants       ')
 
   for nc in range (0,len(consts)):
@@ -632,6 +627,12 @@ def op2_gen_openacc(master, date, consts, kernels):
         num = 'MAX_CONST_SIZE'
 
       code('extern '+consts[nc]['type'][1:-1]+' '+consts[nc]['name']+'['+num+'];')
+
+  comm(' header                 ')
+  if os.path.exists('./user_types.h'):
+    code('#include "../user_types.h"')
+  code('#include "op_lib_c.h"       ')
+  code('')
 
   code('void op_decl_const_char(int dim, char const *type,')
   code('int size, char *dat, char const *name){}')

--- a/translator/c/python/op2_gen_openacc.py
+++ b/translator/c/python/op2_gen_openacc.py
@@ -615,6 +615,7 @@ def op2_gen_openacc(master, date, consts, kernels):
 ##########################################################################
 
   file_text =''
+
   comm(' global constants       ')
 
   for nc in range (0,len(consts)):
@@ -627,8 +628,10 @@ def op2_gen_openacc(master, date, consts, kernels):
         num = 'MAX_CONST_SIZE'
 
       code('extern '+consts[nc]['type'][1:-1]+' '+consts[nc]['name']+'['+num+'];')
+  code('')
 
   comm(' header                 ')
+
   if os.path.exists('./user_types.h'):
     code('#include "../user_types.h"')
   code('#include "op_lib_c.h"       ')

--- a/translator/c/python/op2_gen_openmp.py
+++ b/translator/c/python/op2_gen_openmp.py
@@ -750,11 +750,6 @@ def op2_gen_openmp(master, date, consts, kernels):
 ##########################################################################
 
   file_text =''
-  comm(' header                 ')
-  if os.path.exists('./user_types.h'):
-    code('#include "../user_types.h"')
-  code('#include "op_lib_cpp.h"       ')
-  code('')
   comm(' global constants       ')
 
   for nc in range (0,len(consts)):
@@ -767,6 +762,12 @@ def op2_gen_openmp(master, date, consts, kernels):
         num = 'MAX_CONST_SIZE'
 
       code('extern '+consts[nc]['type'][1:-1]+' '+consts[nc]['name']+'['+num+'];')
+
+  comm(' header                 ')
+  if os.path.exists('./user_types.h'):
+    code('#include "../user_types.h"')
+  code('#include "op_lib_cpp.h"       ')
+  code('')
 
   comm(' user kernel files')
 

--- a/translator/c/python/op2_gen_openmp.py
+++ b/translator/c/python/op2_gen_openmp.py
@@ -750,6 +750,7 @@ def op2_gen_openmp(master, date, consts, kernels):
 ##########################################################################
 
   file_text =''
+
   comm(' global constants       ')
 
   for nc in range (0,len(consts)):
@@ -762,8 +763,10 @@ def op2_gen_openmp(master, date, consts, kernels):
         num = 'MAX_CONST_SIZE'
 
       code('extern '+consts[nc]['type'][1:-1]+' '+consts[nc]['name']+'['+num+'];')
+  code('')
 
   comm(' header                 ')
+
   if os.path.exists('./user_types.h'):
     code('#include "../user_types.h"')
   code('#include "op_lib_cpp.h"       ')

--- a/translator/c/python/op2_gen_openmp4.py
+++ b/translator/c/python/op2_gen_openmp4.py
@@ -807,11 +807,6 @@ def op2_gen_openmp4(master, date, consts, kernels):
 ##########################################################################
 
   file_text =''
-  comm(' header                 ')
-  if os.path.exists('./user_types.h'):
-    code('#include "../user_types.h"')
-  code('#include "op_lib_cpp.h"       ')
-  code('')
   comm(' global constants       ')
 
   for nc in range (0,len(consts)):
@@ -824,6 +819,13 @@ def op2_gen_openmp4(master, date, consts, kernels):
         num = 'MAX_CONST_SIZE'
       code(consts[nc]['type'][1:-1]+' '+consts[nc]['name']+'_ompkernel['+num+'];')
   code('')
+
+  comm(' header                 ')
+  if os.path.exists('./user_types.h'):
+    code('#include "../user_types.h"')
+  code('#include "op_lib_cpp.h"       ')
+  code('')
+
   code('void op_decl_const_char(int dim, char const *type,')
   code('  int size, char *dat, char const *name){')
   indent = ' ' * ( 2+ depth)

--- a/translator/c/python/op2_gen_openmp4.py
+++ b/translator/c/python/op2_gen_openmp4.py
@@ -807,6 +807,7 @@ def op2_gen_openmp4(master, date, consts, kernels):
 ##########################################################################
 
   file_text =''
+
   comm(' global constants       ')
 
   for nc in range (0,len(consts)):
@@ -821,6 +822,7 @@ def op2_gen_openmp4(master, date, consts, kernels):
   code('')
 
   comm(' header                 ')
+
   if os.path.exists('./user_types.h'):
     code('#include "../user_types.h"')
   code('#include "op_lib_cpp.h"       ')

--- a/translator/c/python/op2_gen_openmp_simple.py
+++ b/translator/c/python/op2_gen_openmp_simple.py
@@ -498,11 +498,6 @@ def op2_gen_openmp_simple(master, date, consts, kernels):
 ##########################################################################
 
   file_text =''
-  comm(' header                 ')
-  if os.path.exists('./user_types.h'):
-    code('#include "../user_types.h"')
-  code('#include "op_lib_cpp.h"       ')
-  code('')
   comm(' global constants       ')
 
   for nc in range (0,len(consts)):
@@ -515,6 +510,12 @@ def op2_gen_openmp_simple(master, date, consts, kernels):
         num = 'MAX_CONST_SIZE'
 
       code('extern '+consts[nc]['type'][1:-1]+' '+consts[nc]['name']+'['+num+'];')
+
+  comm(' header                 ')
+  if os.path.exists('./user_types.h'):
+    code('#include "../user_types.h"')
+  code('#include "op_lib_cpp.h"       ')
+  code('')
 
   comm(' user kernel files')
 

--- a/translator/c/python/op2_gen_openmp_simple.py
+++ b/translator/c/python/op2_gen_openmp_simple.py
@@ -498,6 +498,7 @@ def op2_gen_openmp_simple(master, date, consts, kernels):
 ##########################################################################
 
   file_text =''
+
   comm(' global constants       ')
 
   for nc in range (0,len(consts)):
@@ -510,8 +511,10 @@ def op2_gen_openmp_simple(master, date, consts, kernels):
         num = 'MAX_CONST_SIZE'
 
       code('extern '+consts[nc]['type'][1:-1]+' '+consts[nc]['name']+'['+num+'];')
+  code('')
 
   comm(' header                 ')
+
   if os.path.exists('./user_types.h'):
     code('#include "../user_types.h"')
   code('#include "op_lib_cpp.h"       ')

--- a/translator/c/python/op2_gen_seq.py
+++ b/translator/c/python/op2_gen_seq.py
@@ -418,6 +418,7 @@ def op2_gen_seq(master, date, consts, kernels):
 ##########################################################################
 
   file_text =''
+
   comm(' global constants       ')
 
   for nc in range (0,len(consts)):
@@ -430,10 +431,12 @@ def op2_gen_seq(master, date, consts, kernels):
         num = 'MAX_CONST_SIZE'
 
       code('extern '+consts[nc]['type'][1:-1]+' '+consts[nc]['name']+'['+num+'];')
+  code('')
+
+  comm(' header                 ')
 
   if os.path.exists('./user_types.h'):
     code('#include "../user_types.h"')
-  comm(' header                 ')
   code('#include "op_lib_cpp.h"       ')
   code('')
 

--- a/translator/c/python/op2_gen_seq.py
+++ b/translator/c/python/op2_gen_seq.py
@@ -418,11 +418,6 @@ def op2_gen_seq(master, date, consts, kernels):
 ##########################################################################
 
   file_text =''
-  if os.path.exists('./user_types.h'):
-    code('#include "../user_types.h"')
-  comm(' header                 ')
-  code('#include "op_lib_cpp.h"       ')
-  code('')
   comm(' global constants       ')
 
   for nc in range (0,len(consts)):
@@ -435,6 +430,12 @@ def op2_gen_seq(master, date, consts, kernels):
         num = 'MAX_CONST_SIZE'
 
       code('extern '+consts[nc]['type'][1:-1]+' '+consts[nc]['name']+'['+num+'];')
+
+  if os.path.exists('./user_types.h'):
+    code('#include "../user_types.h"')
+  comm(' header                 ')
+  code('#include "op_lib_cpp.h"       ')
+  code('')
 
   comm(' user kernel files')
 


### PR DESCRIPTION
As described [here](https://github.com/OP-DSL/OP2-Common/issues/133), user defined includes are put in separate header file.

Although, inside the includes we referred to the global constants. Therefore we had to put the const declarations before the includes for all backends. I don't think that it will have other unexpected impacts, right?