### PR TITLE
Fix/clang code gen

### DIFF
--- a/translator/c/python/op2_gen_mpi_vec.py
+++ b/translator/c/python/op2_gen_mpi_vec.py
@@ -218,9 +218,14 @@ def op2_gen_mpi_vec(master, date, consts, kernels):
 
           body_text = re.sub('\*\\b'+var2+'\\b\\s*(?!\[)', var2+'[0]', body_text)
           array_access_pattern = '\[[\w\(\)\+\-\*\s\\\\]*\]'
-          ## Replace "+=" with "=". Otherwise leaving them can confuse the compiler's auto-vectoriser (e.g. Clang), 
-          ## and assignment is safe anyway with these intermediate arrays:
-          body_text = re.sub(r'('+var2+array_access_pattern+'\s*'+')'+re.escape("+="), r'\1'+'=', body_text)
+
+          ## Note to developers: the replacement below MAY be needed to vectorize some loops. Take care
+          ## to ensure the regex is finding increments.
+          # if maps[i] == OP_MAP and accs[i] == OP_INC:
+          #   ## Replace increment with write. Otherwise leaving them can confuse the compiler's auto-vectoriser (e.g. Clang), 
+          #   ## and write is safe anyway with these intermediate arrays:
+          #   body_text = re.sub(r'('+var2+array_access_pattern+'\s*'+')'+re.escape("+="), r'\1'+'=', body_text)
+
           ## Append vector array access:
           body_text = re.sub(r'('+var2+array_access_pattern+')', r'\1'+'[idx]', body_text)
 

--- a/translator/c/python/op2_gen_mpi_vec.py
+++ b/translator/c/python/op2_gen_mpi_vec.py
@@ -225,7 +225,10 @@ def op2_gen_mpi_vec(master, date, consts, kernels):
 
 
       #add ( , idx and )
-      signature_text = "inline " + head_text + '( '+new_signature_text + 'int idx ) {'
+      signature_text = "#if defined __clang__ || defined __GNUC__\n"
+      signature_text += "__attribute__((always_inline))\n"
+      signature_text += "#endif\n"
+      signature_text += "inline " + head_text + '( '+new_signature_text + 'int idx ) {'
       #finally update name
       signature_text = signature_text.replace(name,name+'_vec')
 

--- a/translator/c/python/op2_gen_mpi_vec.py
+++ b/translator/c/python/op2_gen_mpi_vec.py
@@ -217,9 +217,14 @@ def op2_gen_mpi_vec(master, date, consts, kernels):
           #print var2
 
           body_text = re.sub('\*\\b'+var2+'\\b\\s*(?!\[)', var2+'[0]', body_text)
-          body_text = re.sub(r'('+var2+'\[[\w\(\)\+\-\*\s\\\\]*\]'+')', r'\1'+'[idx]', body_text)
+          array_access_pattern = '\[[\w\(\)\+\-\*\s\\\\]*\]'
+          ## Replace "+=" with "=". Otherwise leaving them can confuse the compiler's auto-vectoriser (e.g. Clang), 
+          ## and assignment is safe anyway with these intermediate arrays:
+          body_text = re.sub(r'('+var2+array_access_pattern+'\s*'+')'+re.escape("+="), r'\1'+'=', body_text)
+          ## Append vector array access:
+          body_text = re.sub(r'('+var2+array_access_pattern+')', r'\1'+'[idx]', body_text)
 
-          var = var + '[*][SIMD_VEC]'
+          var = var + '[][SIMD_VEC]'
           #var = var + '[restrict][SIMD_VEC]'
         new_signature_text +=  var+', '
 


### PR DESCRIPTION
Two sets of changes to fix vectorisation with Clang compiler (and by extension maybe with GNU).

1 - Add attributes to vec kernels to force inlining into loops.

2 - For loops involving indirect data which is packed into local SIMD arrays, then also pack directly-accessed data into SIMD arrays. Otherwise Clang will not vectorise ; if inner loop is widened to at least SIMD_VEC+2 it will partially-vectorise, performing at least 2 serial iterations + SIMD iteration(s), but this is not full vectorisation.
I have not noticed a performance change with Intel with this additional packing.