### PR TITLE
Fix/clang code gen

### DIFF
--- a/translator/c/python/op2_gen_mpi_vec.py
+++ b/translator/c/python/op2_gen_mpi_vec.py
@@ -218,9 +218,14 @@ def op2_gen_mpi_vec(master, date, consts, kernels):
 
           body_text = re.sub('\*\\b'+var2+'\\b\\s*(?!\[)', var2+'[0]', body_text)
           array_access_pattern = '\[[\w\(\)\+\-\*\s\\\\]*\]'
-          ## Replace "+=" with "=". Otherwise leaving them can confuse the compiler's auto-vectoriser (e.g. Clang), 
-          ## and assignment is safe anyway with these intermediate arrays:
-          body_text = re.sub(r'('+var2+array_access_pattern+'\s*'+')'+re.escape("+="), r'\1'+'=', body_text)
+
+          ## Note to developers: the replacement below MAY be needed to vectorize some loops. Take care
+          ## to ensure the regex is finding increments.
+          # if maps[i] == OP_MAP and accs[i] == OP_INC:
+          #   ## Replace increment with write. Otherwise leaving them can confuse the compiler's auto-vectoriser (e.g. Clang), 
+          #   ## and write is safe anyway with these intermediate arrays:
+          #   body_text = re.sub(r'('+var2+array_access_pattern+'\s*'+')'+re.escape("+="), r'\1'+'=', body_text)
+
           ## Append vector array access:
           body_text = re.sub(r'('+var2+array_access_pattern+')', r'\1'+'[idx]', body_text)
 

--- a/translator/c/python/op2_gen_mpi_vec.py
+++ b/translator/c/python/op2_gen_mpi_vec.py
@@ -225,7 +225,10 @@ def op2_gen_mpi_vec(master, date, consts, kernels):
 
 
       #add ( , idx and )
-      signature_text = "inline " + head_text + '( '+new_signature_text + 'int idx ) {'
+      signature_text = "#if defined __clang__ || defined __GNUC__\n"
+      signature_text += "__attribute__((always_inline))\n"
+      signature_text += "#endif\n"
+      signature_text += "inline " + head_text + '( '+new_signature_text + 'int idx ) {'
       #finally update name
       signature_text = signature_text.replace(name,name+'_vec')
 

--- a/translator/c/python/op2_gen_mpi_vec.py
+++ b/translator/c/python/op2_gen_mpi_vec.py
@@ -389,7 +389,7 @@ def op2_gen_mpi_vec(master, date, consts, kernels):
             code('dat{0}[i] = *((<TYP>*)arg{0}.data);'.format(g_m))
           ENDFOR()
 
-      IF('n+SIMD_VEC >= set->core_size')
+      IF('(n+SIMD_VEC >= set->core_size) && (n+SIMD_VEC-set->core_size < SIMD_VEC)')
       code('op_mpi_wait_all(nargs, args);')
       ENDIF()
       for g_m in range(0,nargs):

--- a/translator/c/python/op2_gen_mpi_vec.py
+++ b/translator/c/python/op2_gen_mpi_vec.py
@@ -217,9 +217,14 @@ def op2_gen_mpi_vec(master, date, consts, kernels):
           #print var2
 
           body_text = re.sub('\*\\b'+var2+'\\b\\s*(?!\[)', var2+'[0]', body_text)
-          body_text = re.sub(r'('+var2+'\[[\w\(\)\+\-\*\s\\\\]*\]'+')', r'\1'+'[idx]', body_text)
+          array_access_pattern = '\[[\w\(\)\+\-\*\s\\\\]*\]'
+          ## Replace "+=" with "=". Otherwise leaving them can confuse the compiler's auto-vectoriser (e.g. Clang), 
+          ## and assignment is safe anyway with these intermediate arrays:
+          body_text = re.sub(r'('+var2+array_access_pattern+'\s*'+')'+re.escape("+="), r'\1'+'=', body_text)
+          ## Append vector array access:
+          body_text = re.sub(r'('+var2+array_access_pattern+')', r'\1'+'[idx]', body_text)
 
-          var = var + '[*][SIMD_VEC]'
+          var = var + '[][SIMD_VEC]'
           #var = var + '[restrict][SIMD_VEC]'
         new_signature_text +=  var+', '
 


### PR DESCRIPTION
As this branch is focused on vectorisation, I included a non-Clang vec bugfix at the end, that can provide a small performance boost (observed 7% for 24 ranks on Skylake).

The replacement of increments with writes not only helps Clang to vectorise, but can give a small performance boost with Intel to compute-bound loops of around 6%.

Much of the textual changes are making the Python code construction clearer.