### PR TITLE
Fix sycl::buffer<> type casting

### DIFF
--- a/op2/c/include/op_sycl_rt_support.h
+++ b/op2/c/include/op_sycl_rt_support.h
@@ -88,28 +88,38 @@ op_plan *op_plan_get_stage_upload(char const *name, op_set set, int part_size,
 
 void op_sycl_exit();
 
-void op_cpHostToDevice(void **data_d, void **data_h, int size);
-void op_mvHostToDevice(void **map, int size);
+void op_cpHostToDevice(void **data_d, void **data_h, int size, const char* type);
+void op_mvHostToDevice(void **map, int size, const char* type);
 
 /*
  * routines to resize constant/reduct arrays, if necessary
  */
 
-void reallocConstArrays(int consts_bytes);
+// UPDATE: sycl::buffer must be type-specific, no more global 
+//         sycl::buffer<char>. This rules out realloc methods.
+// void reallocConstArrays(int consts_bytes);
 
-void reallocReductArrays(int reduct_bytes);
+// void reallocReductArrays(int reduct_bytes);
 
+/*
+ * routines to alloc/free constant/reduct arrays
+ */
+
+void allocConstArrays(int consts_bytes, const char* type);
+void  freeConstArrays(const char* type);
+void allocReductArrays(int reduct_bytes, const char* type);
+void  freeReductArrays(const char* type);
 /*
  * routines to move constant/reduct arrays
  */
 
-void mvConstArraysToDevice(int consts_bytes);
+void mvConstArraysToDevice(int consts_bytes, const char* type);
 
-void mvConstArraysToHost(int consts_bytes);
+void mvConstArraysToHost(int consts_bytes, const char* type);
 
-void mvReductArraysToDevice(int reduct_bytes);
+void mvReductArraysToDevice(int reduct_bytes, const char* type);
 
-void mvReductArraysToHost(int reduct_bytes);
+void mvReductArraysToHost(int reduct_bytes, const char* type);
 
 void *op_sycl_register_const(void *old_p, void *new_p);
 #ifdef __cplusplus

--- a/op2/c/src/sycl/op_sycl_decl.cpp
+++ b/op2/c/src/sycl/op_sycl_decl.cpp
@@ -82,11 +82,11 @@ op_dat op_decl_dat_char(op_set set, int dim, char const *type, int size,
       }
     }
     op_cpHostToDevice((void **)&(dat->data_d), (void **)&(temp_data),
-        dat->size * set->size);
+        dat->size * set->size, type);
     free(temp_data);
   } else {
     op_cpHostToDevice((void **)&(dat->data_d), (void **)&(dat->data),
-                              dat->size * set->size);
+                              dat->size * set->size, type);
 
   }
 
@@ -103,7 +103,7 @@ op_dat op_decl_dat_temp_char(op_set set, int dim, char const *type, int size,
   dat->user_managed = 0;
 
   op_cpHostToDevice((void **)&(dat->data_d), (void **)&(dat->data),
-      dat->size * set->size);
+      dat->size * set->size, type);
 
   return dat;
 }
@@ -130,7 +130,7 @@ op_map op_decl_map(op_set from, op_set to, int dim, int *imap,
     }
   }
   op_cpHostToDevice((void **)&(map->map_d), (void **)&(temp_map),
-                          map->dim * set_size * sizeof(int));
+                          map->dim * set_size * sizeof(int), "int");
   free(temp_map);
   return map;
 }


### PR DESCRIPTION
When creating sycl::buffer<TYPE> objects, TYPE must be specific, no more generic char objects.

Means a change to API as type must be specified when allocating buffers, and the reallocate method has to go unless a record of the old buffer type is kept (which would need new globals in op_sycl_rt_support.h).

Also means cannot translate kernels that use consts/reductions of different types, but user will see a useful message. But did that ever work?...