### PR TITLE
Fixing bug in op_plan_core with non-core colours

### DIFF
--- a/op2/c/Makefile
+++ b/op2/c/Makefile
@@ -169,6 +169,10 @@ ifeq ($(NV_ARCH),Maxwell)
 else
 ifeq ($(NV_ARCH),Pascal)
   CODE_GEN_CUDA=-gencode arch=compute_60,code=sm_60
+else
+ifeq ($(NV_ARCH),Volta)
+  CODE_GEN_CUDA=-gencode arch=compute_70,code=sm_70
+endif
 endif
 endif
 endif

--- a/op2/c/src/core/op_rt_support.c
+++ b/op2/c/src/core/op_rt_support.c
@@ -831,12 +831,12 @@ op_plan *op_plan_core(char const *name, op_set set, int part_size, int nargs,
                                             // non_core ones
           if (prev_offset <= set->core_size)
             OP_plans[ip].ncolors_core = ncolors;
-          for (int shifter = 0; shifter < OP_plans[ip].ncolors_core; shifter++)
+          for (int shifter = 0; shifter < OP_plans[ip].ncolors_core-ncolor; shifter++)
             mask |= 1 << shifter;
           if (prev_offset == set->size && indirect_reduce)
             OP_plans[ip].ncolors_owned = ncolors;
           for (int shifter = OP_plans[ip].ncolors_core;
-               indirect_reduce && shifter < OP_plans[ip].ncolors_owned;
+               indirect_reduce && shifter < OP_plans[ip].ncolors_owned-ncolor;
                shifter++)
             mask |= 1 << shifter;
         }


### PR DESCRIPTION
There was an issue with a large number of block colours, when assigning block colours to non-core or non-owned blocks.