### PR TITLE
Pass flags for line length in FFLAGS

### DIFF
--- a/op2/fortran/Makefile
+++ b/op2/fortran/Makefile
@@ -151,9 +151,9 @@ ifeq ($(OP2_COMPILER),gnu)
   CXX             = g++ #CC 
   CFLAGS          = -g -O2 -std=c99 -fPIC -Wall -pedantic -pipe $(DEBUG_FLAGS)
   CFLAGS_SLOW     = -g -O2 -std=c99 -fPIC -Wall -pedantic -pipe $(DEBUG_FLAGS)
-  FC              = gfortran   -ffixed-line-length-none -ffree-line-length-none #ftn
-  FFLAGS          = -g -O2 -J$(F_INC_MOD) -fPIC -Wall -pedantic -pipe $(DEBUG_FLAGS)
-  FMPI_FLAGS	  = -J$(F_MPI_INC_MOD) -fPIC -Wall -pedantic -pipe $(DEBUG_FLAGS)
+  FC              = gfortran   #ftn
+  FFLAGS          = -g -O2 -J$(F_INC_MOD) -fPIC -Wall -pedantic -pipe $(DEBUG_FLAGS) -ffixed-line-length-none -ffree-line-length-none
+  FMPI_FLAGS	  = -J$(F_MPI_INC_MOD) -fPIC -Wall -pedantic -pipe $(DEBUG_FLAGS) -ffixed-line-length-none -ffree-line-length-none
   MPICC           = mpicc #cc
   MPICXX          = mpicxx #CC
   MPIF90          = mpif90 #ftn


### PR DESCRIPTION
When building with gnu passing these directly to FC breaks if you
need to override FC, e.g. on a Cray machine in PrgEnv-gnu.
Example use case:

module restore PrgEnv-gnu
export OP2_COMPILER=gnu
export OP2_INSTALL_PATH=/path/to/op2/fortran
make CC=cc CXX=CC FC=ftn MPICC=cc MPICXX=CC MPIF90=ftn