### PR TITLE
Improve CUDA target arcitecture selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Finally, to build OP2 and any of the apps:
  1. Set either `OP2_COMPILER={gnu, cray, intel, xl, nvhpc}`, or `OP2_{C, C_CUDA, F}_COMPILER={...}` depending on your compiler setup. Alternatively if there is a profile specific to the cluster you are building on in `makefiles/profiles` you may use e.g. `OP2_PROFILE=cirrus-intel`.
  2. (Optional) Set `PTSCOTCH_INSTALL_PATH`, `PARMETIS_INSTALL_PATH`, and `HDF5_{SEQ, PAR}_INSTALL_PATH` to the locations of the respective dependency builds containing `include` and `lib` folders. Certain build environments such as Spack, Nix and certain environment module implementations may already provided the required library directories through the environent or a compiler wrapper; if this is the case you do not need to set these environment variables.
  3. (Optional) Set `CUDA_INSTALL_PATH` to the location of the installed CUDA toolkit.
+ 4. (Optional) Set `NV_ARCH` to a comma separated list of NVIDIA GPU architectures (`Fermi`, `Kepler`, ..., `Ampere`).
  4. Run `make detect` in the `op2` directory to verify that the compilers, libraries and compilation flags are as you intend.
  5. Run `make -j$(nproc)` in the `op2` directory to build the run-time libraries.
  6. Run `make -j$(nproc)` in any of the app directories to build the respective apps.

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -72,6 +72,12 @@ Then, specify the paths to the library dependency installation directories:
 .. note::
    You may not need to specify the ``X_INSTALL_PATH`` varaibles if the include paths and library search paths are automatically injected by your package manager or module system.
 
+If you are using CUDA then you may also specify a comma separated list of target architectures for which to generate code for:
+
+.. code-block:: shell
+
+   export NV_ARCH={Fermi, Kepler, ..., Ampere}[,{Fermi, ...}]
+
 Verify the compiler and library setup:
 
 .. code-block:: shell

--- a/makefiles/README.md
+++ b/makefiles/README.md
@@ -35,7 +35,7 @@ Available OpenMP features:
 #### `compilers/c_cuda`: The C/C++ CUDA compilers
 Basic compiler setup:
  * `NVCC`: The CUDA compiler executable (e.g. `nvcc`).
- * `NVCCFLAGS`: The flags used for CUDA compilation. These are expected to adhere to `DEBUG` and also enable target-specific code generation if `NV_ARCH={Fermi, Kepler, ..., Volta}` is specified.
+ * `NVCCFLAGS`: The flags used for CUDA compilation. These are expected to adhere to `DEBUG` and also enable target-specific code generation for each of the numerical architectures in the `CUDA_GEN` list.
 
 #### `compilers/fortran`: The Fortran compilers
 Basic compiler setup:
@@ -51,7 +51,7 @@ Available OpenMP features:
  * `F_HAS_OMP_OFFLOAD`: Set to `true` if the Fortran compiler supports OpenMP 4.0 offload.
 
 Available CUDA features:
- * `CUDA_FFLAGS`: The flags to enable compilation of CUDA Fortran (`.CUF`) sources. These should enable target-specific code generation if `NV_ARCH={Fermi, Kepler, ..., Volta}` is specified.
+ * `CUDA_FFLAGS`: The flags to enable compilation of CUDA Fortran (`.CUF`) sources. These should enable target-specific code generation for each of the numerical architectures in the `CUDA_GEN` list.
  * `F_HAS_CUDA`: Set to `true` if the Fortran compiler supports CUDA.
 
 ### `dependencies/`: The dependencies

--- a/makefiles/common.mk
+++ b/makefiles/common.mk
@@ -8,6 +8,11 @@ define UPPERCASE =
 $(shell echo "$(1)" | tr "[:lower:]" "[:upper:]")
 endef
 
+# Helper variables for comma and space substitution
+COMMA := ,
+SPACE :=
+SPACE +=
+
 # Get the makefiles directory (where this file is)
 MAKEFILES_DIR != dirname $(realpath \
 	$(word $(words $(MAKEFILE_LIST)), $(MAKEFILE_LIST)))

--- a/makefiles/compilers.mk
+++ b/makefiles/compilers.mk
@@ -4,6 +4,21 @@ ifdef OP2_COMPILER
   OP2_C_CUDA_COMPILER ?= nvhpc
 endif
 
+# Process CUDA_GEN and NV_ARCH until CUDA_GEN is a whitespace separated list of
+# numerical CUDA architectures
+CUDA_GEN := $(subst $(COMMA),$(SPACE),$(CUDA_GEN))
+
+CUDA_GEN_Fermi   := 20
+CUDA_GEN_Kepler  := 35
+CUDA_GEN_Maxwell := 50
+CUDA_GEN_Pascal  := 60
+CUDA_GEN_Volta   := 70
+CUDA_GEN_Ampere  := 80
+
+NV_ARCH := $(subst $(COMMA),$(SPACE),$(NV_ARCH))
+$(foreach arch,$(NV_ARCH),$(eval CUDA_GEN += $(CUDA_GEN_$(arch))))
+
+# Include the relevant compiler makefiles
 ifdef OP2_C_COMPILER
   include $(MAKEFILES_DIR)/compilers/c/$(OP2_C_COMPILER).mk
 endif

--- a/makefiles/compilers/c/clang.mk
+++ b/makefiles/compilers/c/clang.mk
@@ -1,6 +1,6 @@
 include $(MAKEFILES_DIR)/compilers/c/gnu.mk
 
-CC = clang
-CXX = clang++
+CC := clang
+CXX := clang++
 
 CXXLINK ?= -lc++

--- a/makefiles/compilers/c/cray.mk
+++ b/makefiles/compilers/c/cray.mk
@@ -1,11 +1,11 @@
 # Compiler executables and flags
-CC = cc
-CXX = CC
+CC := cc
+CXX := CC
 
-MPICC = cc
-MPICXX = CC
+MPICC := cc
+MPICXX := CC
 
-BASE_CPPFLAGS = -MMD -MP -Wall -Wextra -pedantic
+BASE_CPPFLAGS := -MMD -MP -Wall -Wextra -pedantic
 
 ifndef DEBUG
   BASE_CPPFLAGS += -O3

--- a/makefiles/compilers/c/gnu.mk
+++ b/makefiles/compilers/c/gnu.mk
@@ -1,8 +1,8 @@
 # Compiler executables and flags
-CC = gcc
-CXX = g++
+CC := gcc
+CXX := g++
 
-BASE_CPPFLAGS = -MMD -MP -Wall -Wextra -pedantic
+BASE_CPPFLAGS := -MMD -MP -Wall -Wextra -pedantic
 
 ifndef DEBUG
   BASE_CPPFLAGS += -O3

--- a/makefiles/compilers/c/intel.mk
+++ b/makefiles/compilers/c/intel.mk
@@ -1,8 +1,8 @@
 # Compiler executables and flags
-CC = icc
-CXX = icpc
+CC := icc
+CXX := icpc
 
-BASE_CPPFLAGS = -MMD -MP -Wall
+BASE_CPPFLAGS := -MMD -MP -Wall
 
 ifndef DEBUG
   BASE_CPPFLAGS += -O3

--- a/makefiles/compilers/c/nvhpc.mk
+++ b/makefiles/compilers/c/nvhpc.mk
@@ -1,8 +1,8 @@
 # Compiler executables and flags
-CC ?= nvcc
-CXX ?= nvc++
+CC := nvcc
+CXX := nvc++
 
-BASE_CPPFLAGS =
+BASE_CPPFLAGS :=
 
 ifndef DEBUG
   BASE_CPPFLAGS += -O3
@@ -19,25 +19,8 @@ CXXLINK ?= -lstdc++
 OMP_CPPFLAGS ?= -mp
 CPP_HAS_OMP ?= true
 
-ifeq ($(NV_ARCH),Fermi)
-  CPP_CUDA_GEN = cc20
-else
-ifeq ($(NV_ARCH),Kepler)
-  CPP_CUDA_GEN = cc35
-else
-ifeq ($(NV_ARCH),Maxwell)
-  CPP_CUDA_GEN = cc50
-else
-ifeq ($(NV_ARCH),Pascal)
-  CPP_CUDA_GEN = cc60
-else
-ifeq ($(NV_ARCH),Volta)
-  CPP_CUDA_GEN = cc70
-endif
-endif
-endif
-endif
-endif
+GPU_FFLAG := -gpu=fastmath,ptxinfo,lineinfo
+$(foreach arch,$(CUDA_GEN),$(eval GPU_FFLAG := $(GPU_FFLAG),cc$(arch)))
 
-OMP_OFFLOAD_CPPFLAGS ?= -mp=gpu -gpu=$(CPP_CUDA_GEN)
+OMP_OFFLOAD_CPPFLAGS ?= -mp=gpu $(GPU_FFLAG)
 CPP_HAS_OMP_OFFLOAD ?= true

--- a/makefiles/compilers/c/xl.mk
+++ b/makefiles/compilers/c/xl.mk
@@ -1,8 +1,8 @@
 # Compiler executables and flags
-CC = xlc_r
-CXX = xlc++_r
+CC := xlc_r
+CXX := xlc++_r
 
-BASE_CPPFLAGS = -MMD -MP -Wall -pedantic
+BASE_CPPFLAGS := -MMD -MP -Wall -pedantic
 
 ifndef DEBUG
   BASE_CPPFLAGS += -O3

--- a/makefiles/compilers/c_cuda/nvhpc.mk
+++ b/makefiles/compilers/c_cuda/nvhpc.mk
@@ -1,33 +1,14 @@
 ifdef CUDA_INSTALL_PATH
-  NVCC ?= $(CUDA_INSTALL_PATH)/bin/nvcc
+  NVCC := $(CUDA_INSTALL_PATH)/bin/nvcc
 else
-  NVCC ?= nvcc
-endif
-
-ifeq ($(NV_ARCH),Fermi)
-  NVCC_GEN = -gencode arch=compute_20,code=sm_21
-else
-ifeq ($(NV_ARCH),Kepler)
-  NVCC_GEN = -gencode arch=compute_35,code=sm_35
-else
-ifeq ($(NV_ARCH),Maxwell)
-  NVCC_GEN = -gencode arch=compute_50,code=sm_50
-else
-ifeq ($(NV_ARCH),Pascal)
-  NVCC_GEN = -gencode arch=compute_60,code=sm_60
-else
-ifeq ($(NV_ARCH),Volta)
-  NVCC_GEN = -gencode arch=compute_70,code=sm_70
-endif
-endif
-endif
-endif
+  NVCC := nvcc
 endif
 
 ifndef DEBUG
-  NVCC_OPT = -O3 -use_fast_math
+  NVCC_OPT := -O3 -use_fast_math
 else
-  NVCC_OPT = -g -O0
+  NVCC_OPT := -g -O0
 endif
 
-NVCCFLAGS ?= $(NVCC_GEN) -m64 -Xptxas=-v $(NVCC_OPT)
+NVCCFLAGS ?= $(foreach arch,$(CUDA_GEN),-gencode arch=compute_$(arch),code=sm_$(arch)) \
+			 -m64 -Xptxas=-v $(NVCC_OPT)

--- a/makefiles/compilers/fortran/cray.mk
+++ b/makefiles/compilers/fortran/cray.mk
@@ -1,8 +1,8 @@
 # Compiler executables and flags
-FC = ftn
-MPIFC = ftn
+FC := ftn
+MPIFC := ftn
 
-BASE_FFLAGS =
+BASE_FFLAGS :=
 
 ifndef DEBUG
   BASE_FFLAGS += -O3

--- a/makefiles/compilers/fortran/gnu.mk
+++ b/makefiles/compilers/fortran/gnu.mk
@@ -1,7 +1,7 @@
 # Compiler executables and flags
-FC = gfortran
+FC := gfortran
 
-BASE_FFLAGS = -Wall -pedantic -ffixed-line-length-none -ffree-line-length-none -fcray-pointer
+BASE_FFLAGS := -Wall -pedantic -ffixed-line-length-none -ffree-line-length-none -fcray-pointer
 
 ifndef DEBUG
   BASE_FFLAGS += -O3

--- a/makefiles/compilers/fortran/intel.mk
+++ b/makefiles/compilers/fortran/intel.mk
@@ -1,7 +1,7 @@
 # Compiler executables and flags
-FC = ifort
+FC := ifort
 
-BASE_FFLAGS = -warn all
+BASE_FFLAGS := -warn all
 
 ifndef DEBUG
   BASE_FFLAGS += -O3

--- a/makefiles/compilers/fortran/nvhpc.mk
+++ b/makefiles/compilers/fortran/nvhpc.mk
@@ -1,7 +1,7 @@
 # Compiler executables and flags
-FC ?= nvfortran
+FC := nvfortran
 
-BASE_FFLAGS =
+BASE_FFLAGS :=
 
 ifndef DEBUG
   BASE_FFLAGS += -O3
@@ -15,33 +15,15 @@ F_MOD_OUT_OPT ?= -module #
 # NVFORTRAN and parallel builds do not mix well...
 F_HAS_PARALLEL_BUILDS ?= false
 
+GPU_FFLAG := -gpu=fastmath,ptxinfo,lineinfo
+$(foreach arch,$(CUDA_GEN),$(eval GPU_FFLAG := $(GPU_FFLAG),cc$(arch)))
+
 # Available OpenMP features
 OMP_FFLAGS ?= -mp
 F_HAS_OMP ?= true
 
-# Available CUDA features
-ifeq ($(NV_ARCH),Fermi)
-  FC_CUDA_GEN = cc20
-else
-ifeq ($(NV_ARCH),Kepler)
-  FC_CUDA_GEN = cc35
-else
-ifeq ($(NV_ARCH),Maxwell)
-  FC_CUDA_GEN = cc50
-else
-ifeq ($(NV_ARCH),Pascal)
-  FC_CUDA_GEN = cc60
-else
-ifeq ($(NV_ARCH),Volta)
-  FC_CUDA_GEN = cc70
-endif
-endif
-endif
-endif
-endif
-
-OMP_OFFLOAD_FFLAGS ?= -mp=gpu -gpu=$(FC_CUDA_GEN)
+OMP_OFFLOAD_FFLAGS ?= -mp=gpu $(GPU_FFLAG)
 F_HAS_OMP_OFFLOAD ?= true
 
-CUDA_FFLAGS ?= -Mcuda=$(FC_CUDA_GEN),fastmath,ptxinfo,lineinfo
+CUDA_FFLAGS ?= $(GPU_FFLAG)
 F_HAS_CUDA ?= true

--- a/makefiles/compilers/fortran/xl.mk
+++ b/makefiles/compilers/fortran/xl.mk
@@ -1,7 +1,7 @@
 # Compiler executables and flags
-FC = xlf_r
+FC := xlf_r
 
-BASE_FFLAGS =
+BASE_FFLAGS :=
 
 ifndef DEBUG
   BASE_FFLAGS += -O3


### PR DESCRIPTION
This replaces the `NV_ARCH` nested ifs in each of the `nvhpc.mk` compiler makefiles with a `CUDA_GEN` variable that is constructed based on the environment `NV_ARCH` and `CUDA_GEN` that allows for multiple target architectures to be specified. In addition, since `CUDA_GEN` is set in `compilers.mk`, the nested if duplication is eliminated.

With this, the old system of specifying `NV_ARCH=Kepler make ...` remains supported (with the addition of the Ampere target), and in addition you can now also do, for example, `CUDA_GEN=50,60 NV_ARCH=Volta,Ampere make ...` and have binaries emitted with PTX code for 50, 60, 70 and 80.

This also allows us to properly support inheriting from `CudaPackage` in the Spack package, as we can pass the full list of `cuda_arch`.