### PR TITLE
Fixing gpudirect issue where gather kernels aren't synced

### DIFF
--- a/op2/include/op_mpi_core.h
+++ b/op2/include/op_mpi_core.h
@@ -399,6 +399,7 @@ void op_download_buffer_async(char *send_buffer_device, char *send_buffer_host, 
 void op_upload_buffer_async  (char *recv_buffer_device, char *recv_buffer_host, unsigned size_recv);
 void op_download_buffer_sync();
 void op_scatter_sync();
+void op_gather_sync();
 #ifdef __cplusplus
 }
 #endif

--- a/op2/src/mpi/op_mpi_cuda_rt_support.cpp
+++ b/op2/src/mpi/op_mpi_cuda_rt_support.cpp
@@ -759,6 +759,13 @@ void op_scatter_sync() {
   cutilSafeCall(cudaEventRecord(op2_grp_download_event, op2_grp_secondary));
   cutilSafeCall(cudaStreamWaitEvent(0, op2_grp_download_event,0));
 }
+
+void op_gather_sync() {
+  // Explicitly sync the gather kernels on the 0 stream when using -gpudirect
+  // as op_download_buffer_async won't be called
+  cutilSafeCall(cudaStreamSynchronize(0));
+}
+
 void op_download_buffer_sync() {
   cutilSafeCall(cudaStreamSynchronize(op2_grp_secondary));
 }

--- a/op2/src/mpi/op_mpi_rt_support.cpp
+++ b/op2/src/mpi/op_mpi_rt_support.cpp
@@ -337,6 +337,7 @@ void op_download_buffer_async(char *send_buffer_device, char *send_buffer_host, 
 void op_upload_buffer_async  (char *recv_buffer_device, char *recv_buffer_host, unsigned size_send) {}
 void op_download_buffer_sync() {}
 void op_scatter_sync() {}
+void op_gather_sync() {}
 #include <vector>
 void gather_data_to_buffer_ptr_cuda(op_arg arg, halo_list eel, halo_list enl, char *buffer, 
                                std::vector<int>& neigh_list, std::vector<unsigned>& neigh_offsets){}

--- a/op2/src/mpi/op_mpi_util.cpp
+++ b/op2/src/mpi/op_mpi_util.cpp
@@ -598,7 +598,8 @@ extern "C"  void op_mpi_wait_all_grouped(int nargs, op_arg *args, int device) {
   //Sends are only started here when running async on the device
   if (device == 2) {
     unsigned curr_offset = 0;
-    op_download_buffer_sync();
+    if(OP_gpu_direct) op_gather_sync();
+    else op_download_buffer_sync();
     for (unsigned i = 0; i < send_neigh_list.size(); i++) {
       char *buf = OP_gpu_direct ? send_buffer_device : send_buffer_host;
 //       int rank;


### PR DESCRIPTION
This pull request fixes #239.

The problem was that the CUDA calls in gather_data_to_buffer_ptr_cuda were being synced in op_download_buffer_async (i.e. gathering the data to the buffer on the device was synced just before the buffer was downloaded from the GPU to the host). However, op_download_buffer_async is not called when using the -gpudirect flag so gathering data to the halo buffer is not synced before the halo is sent over MPI. 

The fix I have implemented is to add op_gather_sync() (similar to op_scatter_sync()) so that the gather kernels can be explicitly synched when using -gpudirect. Then depending on OP_gpu_direct, either op_gather_sync or op_download_buffer_sync is called just before the halos are send over MPI. I've tested this both with the airfoil sample app and my high order FEM code, the issue is no longer occurring in either.

If there is a different way to fix this that would be better just let me know and I'll implement that instead.

Thanks,
Toby