### PR TITLE
Fixes seg fault when a nullptr is passed to op_decl_dat with SoA

### DIFF
--- a/op2/src/cuda/op_cuda_decl.cpp
+++ b/op2/src/cuda/op_cuda_decl.cpp
@@ -125,7 +125,7 @@ op_dat op_decl_dat_char(op_set set, int dim, char const *type, int size,
 
   // transpose data
   size_t set_size = dat->set->size + dat->set->exec_size + dat->set->nonexec_size;
-  if (strstr(type, ":soa") != NULL || (OP_auto_soa && dim > 1)) {
+  if (data != NULL && (strstr(type, ":soa") != NULL || (OP_auto_soa && dim > 1))) {
     char *temp_data = (char *)malloc(dat->size * set_size * sizeof(char));
     int element_size = dat->size / dat->dim;
     for (int i = 0; i < dat->dim; i++) {

--- a/op2/src/cuda/op_cuda_decl.cpp
+++ b/op2/src/cuda/op_cuda_decl.cpp
@@ -132,7 +132,7 @@ op_dat op_decl_dat_char(op_set set, int dim, char const *type, int size,
       for (int j = 0; j < set_size; j++) {
         for (int c = 0; c < element_size; c++) {
           temp_data[element_size * i * set_size + element_size * j + c] =
-              data[dat->size * j + element_size * i + c];
+              dat->data[dat->size * j + element_size * i + c];
         }
       }
     }


### PR DESCRIPTION
A seg fault is occurring when passing a nullptr to op_decl_dat_char when SoA is enabled. This is caused because the data pointer from the function arguments is used instead of the newly allocated data pointer in the op_dat that is created in op_decl_dat_core when converting from AoS to SoA. This pull request changes the AoS to SoA code to use the op_dat's newly allocated/copied data pointer which fixes the issue.