### PR TITLE
Allowing a MPI op_dat to be defined with a null data ptr

### DIFF
--- a/op2/src/mpi/op_mpi_cuda_decl.cpp
+++ b/op2/src/mpi/op_mpi_cuda_decl.cpp
@@ -145,7 +145,7 @@ void op_mpi_init_soa(int argc, char **argv, int diags, MPI_Fint global,
 
 op_dat op_decl_dat_char(op_set set, int dim, char const *type, int size,
                         char *data, char const *name) {
-  if (set == NULL || data == NULL)
+  if (set == NULL)
     return NULL;
   /*char *d = (char *)malloc((size_t)set->size * (size_t)dim * (size_t)size);
   if (d == NULL && set->size>0) {

--- a/op2/src/mpi/op_mpi_decl.cpp
+++ b/op2/src/mpi/op_mpi_decl.cpp
@@ -94,7 +94,7 @@ void op_mpi_init(int argc, char **argv, int diags, MPI_Fint global,
 
 op_dat op_decl_dat_char(op_set set, int dim, char const *type, int size,
                         char *data, char const *name) {
-  if (set == NULL || data == NULL)
+  if (set == NULL)
     return NULL;
   /*char *d = (char *)malloc((size_t)set->size * (size_t)dim * (size_t)size);
   if (d == NULL && set->size>0) {


### PR DESCRIPTION
Resolves #242 

Allows op_dats to be defined with a null data pointer with MPI backends in the same way as single node backends.