### PR TITLE
Fixed syncing gather kernels when using gpudirect

### DIFF
--- a/op2/src/mpi/op_mpi_cuda_kernels.cu
+++ b/op2/src/mpi/op_mpi_cuda_kernels.cu
@@ -38,6 +38,8 @@
 #include <vector>
 #include <algorithm>
 
+extern cudaEvent_t op2_grp_download_event;
+
 __global__ void export_halo_gather(int *list, char *dat, int copy_size,
                                    int elem_size, char *export_buffer) {
   int id = blockIdx.x * blockDim.x + threadIdx.x;
@@ -404,6 +406,7 @@ void gather_data_to_buffer_ptr_cuda(op_arg arg, halo_list eel, halo_list enl, ch
 
   op2_grp_counter++;
 
+  cutilSafeCall(cudaEventRecord(op2_grp_download_event,0));
 }
 
 void scatter_data_from_buffer_ptr_cuda(op_arg arg, halo_list iel, halo_list inl, char *buffer, 

--- a/op2/src/mpi/op_mpi_cuda_rt_support.cpp
+++ b/op2/src/mpi/op_mpi_cuda_rt_support.cpp
@@ -747,7 +747,6 @@ void op_realloc_comm_buffer(char **send_buffer_host, char **recv_buffer_host,
 
 void op_download_buffer_async(char *send_buffer_device, char *send_buffer_host, unsigned size_send) {
   //Make sure gather kernels on the 0 stream finished before starting download
-  cutilSafeCall(cudaEventRecord(op2_grp_download_event,0));
   cutilSafeCall(cudaStreamWaitEvent(op2_grp_secondary, op2_grp_download_event,0));
   cutilSafeCall(cudaMemcpyAsync(send_buffer_host, send_buffer_device, size_send, cudaMemcpyDeviceToHost, op2_grp_secondary));
 }
@@ -761,9 +760,9 @@ void op_scatter_sync() {
 }
 
 void op_gather_sync() {
-  // Explicitly sync the gather kernels on the 0 stream when using -gpudirect
+  // Explicitly sync the gather kernels when using -gpudirect
   // as op_download_buffer_async won't be called
-  cutilSafeCall(cudaStreamSynchronize(0));
+  cutilSafeCall(cudaEventSynchronize(op2_grp_download_event));
 }
 
 void op_download_buffer_sync() {


### PR DESCRIPTION
My previous fix for syncing the gather kernels before the gpudirect MPI halo exchange call ends up waiting for the op2 kernel to finish executing over the core set. This pull request fixes this so that the halo exchange only waits on the gather kernels.